### PR TITLE
fix/Docs-Body-Value

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ app.post('/signup', Celebrate({
   }
 }), (req, res) => {
   // At this point, req.body has been validated and 
-  // req.body.name is equal to req.body.name if provided in the POST or set to 'admin' by joi
+  // req.body.role is equal to req.body.role if provided in the POST or set to 'admin' by joi
 });
 app.use(Celebrate.errors());
 ``` 


### PR DESCRIPTION
Found this as I was reading the documentation. Looks like the comment was pointing to the incorrect body value of `req.body.name` instead of `req.body.role` which had the `.default('admin')` set in the Joi schema.