### PR TITLE
Joi versions 10.x.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 `celebrate` is an Express middleware function that wraps the [joi](https://github.com/hapijs/joi) validation library. This allows you to use this middleware in any single route, or globally, and ensure that all of your inputs are correct before any handler function. The middleware allows you to validate `req.params`, `req.headers`, `req.query` and `req.body` (provided you are using `body-parser`).
 
-`celebrate` uses ["peerDependencies"](https://docs.npmjs.com/files/package.json#peerdependencies) to manage the required version of `joi` it will use. This means that if you're using npm@3, *you must* install a compatible version of `joi` (currently *9.x.x*) as a top level dependency for `celebrate` to work correctly. `celebrate` does *not* install its own copy of `joi` when using npm@3. This is to maximize compatibility and to keep the number of `joi` version mismatch bugs to a minimum.
+`celebrate` uses ["peerDependencies"](https://docs.npmjs.com/files/package.json#peerdependencies) to manage the required version of `joi` it will use. This means that if you're using npm@3, *you must* install a compatible version of `joi` (currently *10.x.x*) as a top level dependency for `celebrate` to work correctly. `celebrate` does *not* install its own copy of `joi` when using npm@3. This is to maximize compatibility and to keep the number of `joi` version mismatch bugs to a minimum.
 
 Wondering why *another* joi middleware library for Express? Full blog post [here](https://blog.continuation.io/time-to-clelebrate/).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "celebrate",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "A joi validation middleware for Express.",
   "main": "lib/index.js",
   "scripts": {
@@ -28,12 +28,12 @@
     "fastseries": "1.7.2"
   },
   "peerDependencies": {
-    "joi": "9.x.x"
+    "joi": "10.x.x"
   },
   "devDependencies": {
     "belly-button": "3.x.x",
     "code": "3.x.x",
-    "joi": "9.x.x",
+    "joi": "10.x.x",
     "lab": "11.x.x"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "celebrate",
-  "version": "4.0.0",
+  "version": "3.0.0",
   "description": "A joi validation middleware for Express.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Joi has just published version 10.0.1.
Since you are using peer dependencies, the package.json had to be changed to be continue to use celebrate with the new Joi version.
I have made the changed and run the tests. Everything passed.
I also changed the version to 4.0.0 because of the compatibility break.
