### PR TITLE
Move validated values

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,12 @@ Example of using `celebrate` on a single POST route to validate `req.body`.
 ```js
 const express = require('express');
 const BodyParser = require('body-parser');
-const Celebrate = require('celebrate');
-const { Joi } = Celebrate;
+const { celebrate, Joi, errors } = require('celebrate');
 
 const app = express();
 app.use(BodyParser.json());
 
-app.post('/signup', Celebrate({
+app.post('/signup', celebrate({
   body: Joi.object().keys({
     name: Joi.string().required(),
     age: Joi.number().integer(),
@@ -39,48 +38,57 @@ app.post('/signup', Celebrate({
   }
 }), (req, res) => {
   // At this point, req.body has been validated and 
-  // req.body.role is equal to req.body.role if provided in the POST or set to 'admin' by joi
+  // res.locals.celebrate.body.role is equal the role provided in the POST or set to 'admin' by joi
 });
-app.use(Celebrate.errors());
+app.use(errors());
 ``` 
 
 Example of using `celebrate` to validate all incoming requests to ensure the `token` header is present and matches the supplied regular expression.
 ```js
 const express = require('express');
-const Celebrate = require('celebrate');
-const { Joi } = Celebrate;
+const { celebrate, Joi, errors} = require('celebrate');
 const app = express();
 
 // validate all incoming request headers for the token header
 // if missing or not the correct format, respond with an error
-app.use(Celebrate({
+app.use(celebrate({
  headers: Joi.object({
    token: Joi.string().required().regex(/abc\d{3}/)
  }).unknown()
 }));
 app.get('/', (req, res) => { res.send('hello world'); });
 app.get('/foo', (req, res) => { res.send('a foo request'); });
-app.use(Celebrate.errors());
+app.use(errors());
 ```
 
 ## API
 
-### `Celebrate(schema, [options])`
+### `celebrate(schema, [options])`
 
-The single exported function from `celebrate`. Returns a `function` with the middleware signature (`(req, res, next)`).
+Returns a `function` with the middleware signature (`(req, res, next)`).
 
 - `schema` - a object where `key` can be one of `'params', 'headers', 'query', and 'body'` and the `value` is a [joi](https://github.com/hapijs/joi/blob/master/API.md) validation schema. Only the `key`s specified will be validated against the incoming `req` object. If you omit a key, that part of the `req` object will not be validated. A schema must contain at least one of the valid keys. 
 - `[options]` - `joi` [options](https://github.com/hapijs/joi/blob/master/API.md#validatevalue-schema-options-callback) that are passed directly into the `validate` function. Defaults to `{ escapeHtml: true }`. This is differs from the Joi defaults since version 12.
 
-### `Celebrate.errors()`
+Because of the changes coming in Express 5, `celebrate` no longer overwrites values on `req`. Instead, it sets the validated values inside `res.locals.celebate`. There is a utility function (`values`) for retrieving these values and you should avoid accessing them directly as the path could change in the future. When requests pass through the `celebrate` middleware, all of the request values (`'params', 'headers', 'query', and 'body'`) are copied over into `res.locals.celebrate` even if they are not valided. This is done so Celebrate users don't have to look in two different places for request input values, any route that uses `celebrate` will always have them availible via `values(res)`.
+
+### `errors()`
 
 Returns a `function` with the error handler signature (`(err, req, res, next)`). This should be placed with any other error handling middleware to catch Joi validation errors. If the incoming `err` object is a Joi error, `errors()` will respond with a 400 status code and the Joi validation message. Otherwise, it will call `next(err)` and will pass the error along and need to be processed by another error handler.
 
 If the error format does not suite your needs, you an encouraged to write your own error handler and check `err.isJoi` to format joi errors to your liking. The full joi error object will be available in your own error handler.
 
-### `Celebrate.Joi`
+### `Joi`
 
 `celebrate` exports the version of joi it is using internally. For maximum compatibility, you should use this version when passing in any validation schemas.
+
+### `values(res, [fallback])`
+
+A utility function for extracting validated values from the incoming request. You pass in a `res` object that has gone through the `celebrate` middleware as well as an express `req` object as a fallback. This function returns an object with `'params', 'headers', 'query', and ['body']`
+attached to it. 
+
+`res` - an Express response object that has gone through `celebrate` middleware
+`[fallback]` - an object to use as a fallback in instances where `res` does not have the request input values set. 99% of the time, this should be the `req` object in an express route handler.
 
 ## Order
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,16 +5,56 @@ const Assert = require('assert');
 const Joi = require('joi');
 const EscapeHtml = require('escape-html');
 
-const validations = require('./schema');
+const get = require('lodash/get');
+const set = require('lodash/set');
+const pick = require('lodash/pick');
 
-const Celebrate = (schema, options) => {
+const validations = require('./schema');
+const defaults = {
+  escapeHtml: true
+};
+
+const SEGMENT = ['locals', 'celebrate'];
+
+const validateSource = (source) => {
+  return (config, next) => {
+    const req = config.req;
+    const res = config.res;
+    const options = config.options;
+    const rules = config.rules;
+    const spec = rules.get(source);
+    const path = SEGMENT.concat(source);
+
+    // copy it over so you can go to the same place for everything
+    set(res, path, req[source]);
+
+    if (!spec) {
+      return next(null);
+    }
+    Joi.validate(req[source], spec, options, (err, value) => {
+      if (value !== undefined) {
+        // Apply any Joi transforms back to
+        set(res, path, value);
+      }
+      if (err) {
+        err._meta = { source };
+        return next(err);
+      }
+      return next(null);
+    });
+  };
+};
+
+const validateHeaders = validateSource('headers');
+const validateParams = validateSource('params');
+const validateQuery = validateSource('query');
+const validateBody = validateSource('body');
+
+const celebrate = (schema, options) => {
   const result = Joi.validate(schema || {}, validations.schema);
   Assert.ifError(result.error);
   const rules = new Map();
 
-  const defaults = {
-    escapeHtml: true
-  };
   options = Object.assign(defaults, options);
 
   const keys = Object.keys(schema);
@@ -23,42 +63,27 @@ const Celebrate = (schema, options) => {
     rules.set(key, Joi.compile(schema[key]));
   }
 
-  const validateSource = (source) => {
-    return (req, callback) => {
-      const spec = rules.get(source);
-
-      if (!spec) {
-        return callback(null);
-      }
-
-      Joi.validate(req[source], spec, options, (err, value) => {
-        if (value !== undefined) {
-          // Apply any Joi transforms back to the request
-          req[source] = value;
-        }
-        if (err) {
-          err._meta = { source };
-          return callback(err);
-        }
-        return callback(null);
-      });
-    };
-  };
-
-  const validateBody = validateSource('body');
   const middleware = (req, res, next) => {
+    set(res, SEGMENT, {});
+    const config = {
+      req,
+      res,
+      options,
+      rules
+    };
     Series(null, [
-      validateSource('headers'),
-      validateSource('params'),
-      validateSource('query'),
-      function (req, callback) {
+      validateHeaders,
+      validateParams,
+      validateQuery,
+      function (config, callback) {
+        const req = config.req;
         const method = req.method.toLowerCase();
         if (method === 'get' || method === 'head') {
           return callback(null);
         }
-        validateBody(req, callback);
+        validateBody(config, callback);
       }
-    ], req, next);
+    ], config, next);
   };
 
   middleware._schema = schema;
@@ -66,7 +91,7 @@ const Celebrate = (schema, options) => {
   return middleware;
 };
 
-Celebrate.errors = () => {
+const errors = () => {
   return (err, req, res, next) => {
     if (err.isJoi) {
       const error = {
@@ -94,6 +119,14 @@ Celebrate.errors = () => {
   };
 };
 
-Celebrate.Joi = Joi;
+const values = (res, req) => {
+  req = req || {};
+  return get(res, SEGMENT, pick(req, ['headers', 'params', 'query', 'body']));
+};
 
-module.exports = Celebrate;
+module.exports = {
+  celebrate,
+  errors,
+  Joi,
+  values
+};

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "dependencies": {
     "escape-html": "1.0.3",
     "fastseries": "1.7.2",
-    "joi": "12.x.x"
+    "joi": "12.x.x",
+    "lodash": "4.17.x"
   },
   "devDependencies": {
     "@types/express": "4.x.x",


### PR DESCRIPTION
Change public AP

Closes #46
Closes #44

Move validated values to res.locals.celebrate and added utility functions to get them. This is to maximize compatibility
and to stop overwriting the incomming HTTP parameters.

Updates the public API to export an object, rather than a single function.