### PR TITLE
Don't handle Joi errors that are not generated by celebrate

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,8 @@ const EscapeHtml = require('escape-html');
 
 const validations = require('./schema');
 
+const isCelebrate = Symbol('isCelebrate');
+
 const Celebrate = (schema, options) => {
   const result = Joi.validate(schema || {}, validations.schema);
   Assert.ifError(result.error);
@@ -37,6 +39,7 @@ const Celebrate = (schema, options) => {
           req[source] = value;
         }
         if (err) {
+          err[isCelebrate] = true;
           err._meta = { source };
           return callback(err);
         }
@@ -68,7 +71,7 @@ const Celebrate = (schema, options) => {
 
 Celebrate.errors = () => {
   return (err, req, res, next) => {
-    if (err.isJoi) {
+    if (err[isCelebrate]) {
       const error = {
         statusCode: 400,
         error: 'Bad Request',

--- a/test/__snapshots__/celebrate.test.js.snap
+++ b/test/__snapshots__/celebrate.test.js.snap
@@ -12,15 +12,13 @@ Object {
 }
 `;
 
-exports[`Celebrate Middleware errors() responds with a joi error 1`] = `
+exports[`Celebrate Middleware errors() responds with a joi error from celebrate middleware 1`] = `
 Object {
   "error": "Bad Request",
-  "message": "child \\"first\\" fails because [\\"first\\" is required]. child \\"last\\" fails because [\\"last\\" is required]. child \\"role\\" fails because [\\"role\\" must be a number]",
+  "message": "child \\"role\\" fails because [\\"role\\" must be larger than or equal to 4]",
   "statusCode": 400,
   "validation": Object {
     "keys": Array [
-      "first",
-      "last",
       "role",
     ],
     "source": "query",


### PR DESCRIPTION
# Issue

- `node` version - 6
- `celebrate` version - 4.0.3
- `joi` version (via `npm ls --depth=0 | grep joi`) - 10.6.0

The issue I am having with `celebrate` is:

I am working on an application that uses Joi for other validation as well as using celebrate. When next is called with any Joi error, the celebrate error handler intercepts it, and if it is not from celebrate it throws the following error:.

```
TypeError: Cannot read property 'source' of undefined
    at /usr/src/app/node_modules/celebrate/lib/index.js:71:28
```

The celebrate errors middleware should ignore any errors not from celebrate, so maybe as well as setting `err._meta = { source }` it should set `err._isCelebrate = true` and use this instead of `err.isJoi`?

Will happily raise a PR if you agree with this approach.

# Resolution

- Add "isCelebrate" Symbol to the Joi error before passing it through next in middleware
- When passing through the error handler check err has "isCelebrate" Symbol instead of err.isJoi
- Update tests for error handler to use the celebrate middleware to generate errors that should be handled