### PR TITLE
API refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,12 @@ Example of using `celebrate` on a single POST route to validate `req.body`.
 ```js
 const express = require('express');
 const BodyParser = require('body-parser');
-const Celebrate = require('celebrate');
-const { Joi } = Celebrate;
+const { celebrate, Joi, errors } = require('celebrate');
 
 const app = express();
 app.use(BodyParser.json());
 
-app.post('/signup', Celebrate({
+app.post('/signup', celebrate({
   body: Joi.object().keys({
     name: Joi.string().required(),
     age: Joi.number().integer(),
@@ -44,14 +43,13 @@ app.post('/signup', Celebrate({
   // At this point, req.body has been validated and 
   // req.body.role is equal to req.body.role if provided in the POST or set to 'admin' by joi
 });
-app.use(Celebrate.errors());
+app.use(errors());
 ``` 
 
 Example of using `celebrate` to validate all incoming requests to ensure the `token` header is present and matches the supplied regular expression.
 ```js
 const express = require('express');
-const Celebrate = require('celebrate');
-const { Joi } = Celebrate;
+const { celebrate, Joi, errors } = require('celebrate');
 const app = express();
 
 // validate all incoming request headers for the token header
@@ -63,25 +61,25 @@ app.use(Celebrate({
 }));
 app.get('/', (req, res) => { res.send('hello world'); });
 app.get('/foo', (req, res) => { res.send('a foo request'); });
-app.use(Celebrate.errors());
+app.use(errors());
 ```
 
 ## API
 
-### `Celebrate(schema, [options])`
+### `celebrate(schema, [options])`
 
-The single exported function from `celebrate`. Returns a `function` with the middleware signature (`(req, res, next)`).
+Returns a `function` with the middleware signature (`(req, res, next)`).
 
 - `schema` - a object where `key` can be one of `'params', 'headers', 'query', and 'body'` and the `value` is a [joi](https://github.com/hapijs/joi/blob/master/API.md) validation schema. Only the `key`s specified will be validated against the incoming `req` object. If you omit a key, that part of the `req` object will not be validated. A schema must contain at least one of the valid keys. 
 - `[options]` - `joi` [options](https://github.com/hapijs/joi/blob/master/API.md#validatevalue-schema-options-callback) that are passed directly into the `validate` function. Defaults to `{ escapeHtml: true }`. This is differs from the Joi defaults since version 12.
 
-### `Celebrate.errors()`
+### `errors()`
 
 Returns a `function` with the error handler signature (`(err, req, res, next)`). This should be placed with any other error handling middleware to catch Joi validation errors. If the incoming `err` object is a Joi error, `errors()` will respond with a 400 status code and the Joi validation message. Otherwise, it will call `next(err)` and will pass the error along and need to be processed by another error handler.
 
 If the error format does not suite your needs, you an encouraged to write your own error handler and check `err.isJoi` to format joi errors to your liking. The full joi error object will be available in your own error handler.
 
-### `Celebrate.Joi`
+### `Joi`
 
 `celebrate` exports the version of joi it is using internally. For maximum compatibility, you should use this version when passing in any validation schemas.
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,19 +1,18 @@
 import { ErrorRequestHandler, RequestHandler } from 'express';
 
-/**
- * Creates a Celebrate middleware function.
- * @param {object} schema object where each key is one of ["params", "headers", "query", "body"] and the value is
- * a Joi schema.
- * @param {object} config optional configuration options that will be passed directly into Joi.
- */
-declare function Celebrate (schema: {
-    params?: object,
-    headers?: object,
-    query?: object,
-    body?: object,
-}, config?: object): RequestHandler;
-
 declare namespace Celebrate {
+    /**
+    * Creates a Celebrate middleware function.
+    * @param {object} schema object where each key is one of ["params", "headers", "query", "body"] and the value is
+    * a Joi schema.
+    * @param {object} config optional configuration options that will be passed directly into Joi.
+    */
+    function celebrate(schema: {
+        params?: object,
+        headers?: object,
+        query?: object,
+        body?: object,
+    }, config?: object): RequestHandler
     /**
      * Creates a Celebrate error handler middleware function.
      */

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,68 +6,76 @@ const Joi = require('joi');
 const EscapeHtml = require('escape-html');
 
 const validations = require('./schema');
-
 const isCelebrate = Symbol('isCelebrate');
+const DEFAULTS = {
+  escapeHtml: true
+};
 
-const Celebrate = (schema, options) => {
+const validateSource = (source) => {
+  return (config, next) => {
+    const req = config.req;
+    const options = config.options;
+    const rules = config.rules;
+    const spec = rules.get(source);
+
+    if (!spec) {
+      return next(null);
+    }
+    Joi.validate(req[source], spec, options, (err, value) => {
+      if (value !== undefined) {
+        const descriptor = Object.getOwnPropertyDescriptor(req, source);
+        /* istanbul ignore next */
+        if (descriptor && descriptor.writable) {
+          req[source] = value;
+        } else {
+          Object.defineProperty(req, source, {
+            get () { return value; }
+          });
+        }
+      }
+      if (err) {
+        err[isCelebrate] = true;
+        err._meta = { source };
+        return next(err);
+      }
+      return next(null);
+    });
+  };
+};
+
+const validateHeaders = validateSource('headers');
+const validateParams = validateSource('params');
+const validateQuery = validateSource('query');
+const validateBody = validateSource('body');
+
+const celebrate = (schema, options) => {
   const result = Joi.validate(schema || {}, validations.schema);
   Assert.ifError(result.error);
   const rules = new Map();
-
-  const defaults = {
-    escapeHtml: true
-  };
-  options = Object.assign(defaults, options);
+  options = Object.assign({}, DEFAULTS, options);
 
   const keys = Object.keys(schema);
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];
     rules.set(key, Joi.compile(schema[key]));
   }
-
-  const validateSource = (source) => {
-    return (req, callback) => {
-      const spec = rules.get(source);
-
-      if (!spec) {
-        return callback(null);
-      }
-      Joi.validate(req[source], spec, options, (err, value) => {
-        if (value !== undefined) {
-          const descriptor = Object.getOwnPropertyDescriptor(req, source);
-          /* istanbul ignore next */
-          if (descriptor && descriptor.writable) {
-            req[source] = value;
-          } else {
-            Object.defineProperty(req, source, {
-              get () { return value; }
-            });
-          }
-        }
-        if (err) {
-          err[isCelebrate] = true;
-          err._meta = { source };
-          return callback(err);
-        }
-        return callback(null);
-      });
-    };
-  };
-
-  const validateBody = validateSource('body');
   const middleware = (req, res, next) => {
     Series(null, [
-      validateSource('headers'),
-      validateSource('params'),
-      validateSource('query'),
-      function (req, callback) {
-        const method = req.method.toLowerCase();
+      validateHeaders,
+      validateParams,
+      validateQuery,
+      (config, callback) => {
+        const method = config.req.method.toLowerCase();
         if (method === 'get' || method === 'head') {
           return callback(null);
         }
-        validateBody(req, callback);
+        validateBody(config, callback);
       }
-    ], req, next);
+    ], {
+      req,
+      options,
+      rules
+    }, next);
   };
 
   middleware._schema = schema;
@@ -75,7 +83,7 @@ const Celebrate = (schema, options) => {
   return middleware;
 };
 
-Celebrate.errors = () => {
+const errors = () => {
   return (err, req, res, next) => {
     if (err[isCelebrate]) {
       const error = {
@@ -103,6 +111,9 @@ Celebrate.errors = () => {
   };
 };
 
-Celebrate.Joi = Joi;
 
-module.exports = Celebrate;
+module.exports = {
+  celebrate,
+  Joi,
+  errors
+};

--- a/test/celebrate.test.js
+++ b/test/celebrate.test.js
@@ -2,13 +2,16 @@
 
 const expect = require('expect');
 const Celebrate = require('../lib');
+
+const celebrate = Celebrate.celebrate;
 const Joi = Celebrate.Joi;
+const errors = Celebrate.errors;
 
 describe('Celebrate Middleware', () => {
   it('throws an error if using an invalid schema', () => {
     expect.assertions(3);
     expect(() => {
-      Celebrate({
+      celebrate({
         query: {
           name: Joi.string(),
           age: Joi.number()
@@ -18,17 +21,17 @@ describe('Celebrate Middleware', () => {
     }).toThrow('"foo" is not allowed');
 
     expect(() => {
-      Celebrate();
+      celebrate();
     }).toThrow('"value" must have at least 1 children');
 
     expect(() => {
-      Celebrate(false);
+      celebrate(false);
     }).toThrow('"value" must have at least 1 children');
   });
 
   it('validates req.headers', () => {
     expect.assertions(2);
-    const middleware = Celebrate({
+    const middleware = celebrate({
       headers: {
         accept: Joi.string().regex(/xml/)
       }
@@ -46,7 +49,7 @@ describe('Celebrate Middleware', () => {
 
   it('validates req.params', () => {
     expect.assertions(2);
-    const middleware = Celebrate({
+    const middleware = celebrate({
       params: {
         id: Joi.string().token()
       }
@@ -64,7 +67,7 @@ describe('Celebrate Middleware', () => {
 
   it('validates req.query', () => {
     expect.assertions(2);
-    const middleware = Celebrate({
+    const middleware = celebrate({
       query: Joi.object().keys({
         start: Joi.date()
       })
@@ -82,7 +85,7 @@ describe('Celebrate Middleware', () => {
 
   it('validates req.body', () => {
     expect.assertions(2);
-    const middleware = Celebrate({
+    const middleware = celebrate({
       body: {
         first: Joi.string().required(),
         last: Joi.string(),
@@ -104,7 +107,7 @@ describe('Celebrate Middleware', () => {
 
   it('errors on the first validation problem (params, query, body)', () => {
     expect.assertions(2);
-    const middleware = Celebrate({
+    const middleware = celebrate({
       params: {
         id: Joi.string().required()
       },
@@ -145,7 +148,7 @@ describe('Celebrate Middleware', () => {
       query: undefined,
       method: 'POST'
     };
-    const middleware = Celebrate({
+    const middleware = celebrate({
       body: {
         first: Joi.string().required(),
         last: Joi.string(),
@@ -167,7 +170,7 @@ describe('Celebrate Middleware', () => {
 
   it('does not validate req.body if the method is "GET" or "HEAD"', () => {
     expect.assertions(1);
-    const middleware = Celebrate({
+    const middleware = celebrate({
       body: {
         first: Joi.string().required(),
         last: Joi.string(),
@@ -202,7 +205,7 @@ describe('Celebrate Middleware', () => {
       }]
     });
 
-    const middleware = Celebrate({
+    const middleware = celebrate({
       body: {
         first: _Joi.string().required().isJohn(),
         role: _Joi.number().integer()
@@ -223,7 +226,7 @@ describe('Celebrate Middleware', () => {
 
   it('uses the supplied the Joi options', () => {
     expect.assertions(2);
-    const middleware = Celebrate({
+    const middleware = celebrate({
       query: Joi.object().keys({
         page: Joi.number()
       })
@@ -244,7 +247,7 @@ describe('Celebrate Middleware', () => {
 
   it('honors the escapeHtml Joi option', () => {
     expect.assertions(2);
-    const middleware = Celebrate({
+    const middleware = celebrate({
       headers: {
         accept: Joi.string().regex(/xml/)
       }
@@ -263,12 +266,12 @@ describe('Celebrate Middleware', () => {
   describe('errors()', () => {
     it('responds with a joi error from celebrate middleware', () => {
         expect.assertions(3);
-        const middleware = Celebrate({
+        const middleware = celebrate({
           query: {
             role: Joi.number().integer().min(4)
           }
         });
-        const handler = Celebrate.errors();
+        const handler = errors();
         const next = jest.fn();
         const res = {
           status (statusCode) {
@@ -294,7 +297,7 @@ describe('Celebrate Middleware', () => {
 
     it('passes the error through next if not a joi error from celebrate middleware', () => {
         let errorDirectlyFromJoi = null;
-        const handler = Celebrate.errors();
+        const handler = errors();
         const res = {
           status (statusCode) {
             Code.fail('status called');
@@ -316,12 +319,12 @@ describe('Celebrate Middleware', () => {
 
     it('only includes key values if joi returns details', () => {
       expect.assertions(3);
-      const middleware = Celebrate({
+      const middleware = celebrate({
         body: {
           first: Joi.string().required()
         }
       });
-      const handler = Celebrate.errors();
+      const handler = errors();
       const next = jest.fn();
       const res = {
         status (statusCode) {

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -2,7 +2,9 @@ const Express = require('express');
 const Artificial = require('artificial');
 const BodyParser = require('body-parser');
 const Celebrate = require('../lib');
-const Joi = Celebrate.Joi
+
+const celebrate = Celebrate.celebrate;
+const Joi = Celebrate.Joi;
 const errors = Celebrate.errors;
 
 const Server = () => {
@@ -18,7 +20,7 @@ describe('express integration', () => {
       expect.assertions(2);
       const server = Server();
   
-      server.get('/', Celebrate({
+      server.get('/', celebrate({
         headers: {
           accept: Joi.string().regex(/xml/)
         }
@@ -44,7 +46,7 @@ describe('express integration', () => {
     it('req.params', (done) => {
       expect.assertions(2);
       const server = Server();
-      server.get('/user/:id', Celebrate({
+      server.get('/user/:id', celebrate({
         params: {
           id: Joi.string().token()
         }
@@ -66,7 +68,7 @@ describe('express integration', () => {
       expect.assertions(2);
       const server = Server();
   
-      server.get('/', Celebrate({
+      server.get('/', celebrate({
         query: Joi.object().keys({
           start: Joi.date()
         })
@@ -86,7 +88,7 @@ describe('express integration', () => {
     it('req.body', (done) => {
       expect.assertions(2);
       const server = Server();
-      server.post('/', Celebrate({
+      server.post('/', celebrate({
         body: {
           first: Joi.string().required(),
           last: Joi.string(),
@@ -115,7 +117,7 @@ describe('express integration', () => {
       expect.assertions(1);
       const server = Server();
   
-      server.get('/', Celebrate({
+      server.get('/', celebrate({
         headers: {
           accept: Joi.string().regex(/json/),
           ['secret-header']: Joi.string().default('@@@@@@')
@@ -144,7 +146,7 @@ describe('express integration', () => {
     it('req.params', (done) => {
       expect.assertions(1);
       const server = Server();
-      server.get('/user/:id', Celebrate({
+      server.get('/user/:id', celebrate({
         params: {
           id: Joi.string().uppercase()
         }
@@ -163,7 +165,7 @@ describe('express integration', () => {
       expect.assertions(1);
       const server = Server();
   
-      server.get('/', Celebrate({
+      server.get('/', celebrate({
         query: Joi.object().keys({
           name: Joi.string().uppercase(),
           page: Joi.number().default(1),
@@ -185,7 +187,7 @@ describe('express integration', () => {
     it('req.body', (done) => {
       expect.assertions(1);
       const server = Server();
-      server.post('/', Celebrate({
+      server.post('/', celebrate({
         body: {
           first: Joi.string().required(),
           last: Joi.string().default('Smith'),


### PR DESCRIPTION
Closes #46

Change the exports to be an object with APIs attached to it, rather than just a function.