### PR TITLE
Added isCelebrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ If the error format does not suite your needs, you an encouraged to write your o
 
 ### `isCelebrate(err)`
 
-Returns `true` if the provided `err` object originated from the `celebrate` middleware. Usseful if you want to write your own error handler for `celebrate` errors.
+Returns `true` if the provided `err` object originated from the `celebrate` middleware, and `false` otherwise. Useful if you want to write your own error handler for `celebrate` errors.
 
 - `err` - an error object
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ If the error format does not suite your needs, you an encouraged to write your o
 
 `celebrate` exports the version of joi it is using internally. For maximum compatibility, you should use this version when passing in any validation schemas.
 
+### `isCelebrate(err)`
+
+Returns `true` if the provided `err` object originated from the `celebrate` middleware. Usseful if you want to write your own error handler for `celebrate` errors.
+
+- `err` - an error object
+
 ## Order
 
 `celebrate` validates `req` values in the following order:

--- a/lib/index.js
+++ b/lib/index.js
@@ -48,7 +48,12 @@ const validateParams = validateSource('params');
 const validateQuery = validateSource('query');
 const validateBody = validateSource('body');
 
-const isCelebrate = (err) => { return err[CELEBRATED]; };
+const isCelebrate = (err) => {
+  if (err != null && typeof err === 'object') { // eslint-disable-line eqeqeq
+    return err[CELEBRATED] || false;
+  }
+  return false;
+};
 
 const celebrate = (schema, options) => {
   const result = Joi.validate(schema || {}, validations.schema);

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ const Joi = require('joi');
 const EscapeHtml = require('escape-html');
 
 const validations = require('./schema');
-const isCelebrate = Symbol('isCelebrate');
+const CELEBRATED = Symbol('isCelebrate');
 const DEFAULTS = {
   escapeHtml: true
 };
@@ -34,7 +34,7 @@ const validateSource = (source) => {
         }
       }
       if (err) {
-        err[isCelebrate] = true;
+        err[CELEBRATED] = true;
         err._meta = { source };
         return next(err);
       }
@@ -47,6 +47,8 @@ const validateHeaders = validateSource('headers');
 const validateParams = validateSource('params');
 const validateQuery = validateSource('query');
 const validateBody = validateSource('body');
+
+const isCelebrate = (err) => { return err[CELEBRATED]; };
 
 const celebrate = (schema, options) => {
   const result = Joi.validate(schema || {}, validations.schema);
@@ -85,7 +87,7 @@ const celebrate = (schema, options) => {
 
 const errors = () => {
   return (err, req, res, next) => {
-    if (err[isCelebrate]) {
+    if (isCelebrate(err)) {
       const error = {
         statusCode: 400,
         error: 'Bad Request',
@@ -111,9 +113,9 @@ const errors = () => {
   };
 };
 
-
 module.exports = {
   celebrate,
   Joi,
-  errors
+  errors,
+  isCelebrate
 };

--- a/test/__snapshots__/celebrate.test.js.snap
+++ b/test/__snapshots__/celebrate.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Celebrate Middleware errors() only includes key values if joi returns details 1`] = `
+exports[`Celebrate errors() only includes key values if joi returns details 1`] = `
 Object {
   "error": "Bad Request",
   "message": "child \\"first\\" fails because [\\"first\\" is required]",
@@ -12,7 +12,7 @@ Object {
 }
 `;
 
-exports[`Celebrate Middleware errors() responds with a joi error from celebrate middleware 1`] = `
+exports[`Celebrate errors() responds with a joi error from celebrate middleware 1`] = `
 Object {
   "error": "Bad Request",
   "message": "child \\"role\\" fails because [\\"role\\" must be larger than or equal to 4]",

--- a/test/celebrate.test.js
+++ b/test/celebrate.test.js
@@ -6,8 +6,9 @@ const Celebrate = require('../lib');
 const celebrate = Celebrate.celebrate;
 const Joi = Celebrate.Joi;
 const errors = Celebrate.errors;
+const isCelebrate = Celebrate.isCelebrate;
 
-describe('Celebrate Middleware', () => {
+describe('Celebrate', () => {
   it('throws an error if using an invalid schema', () => {
     expect.assertions(3);
     expect(() => {
@@ -42,7 +43,7 @@ describe('Celebrate Middleware', () => {
         accept: 'application/json'
       }
     }, null, (err) => {
-      expect(err.isJoi).toBe(true);
+      expect(isCelebrate(err)).toBe(true);
       expect(err.details[0].message).toBe('"accept" with value "application&#x2f;json" fails to match the required pattern: /xml/');
     });
   });
@@ -60,7 +61,7 @@ describe('Celebrate Middleware', () => {
         id: '@@@'
       }
     }, null, (err) => {
-      expect(err.isJoi).toBe(true);
+      expect(isCelebrate(err)).toBe(true);
       expect(err.details[0].message).toBe('"id" must only contain alpha-numeric and underscore characters');
     });
   });
@@ -78,7 +79,7 @@ describe('Celebrate Middleware', () => {
         end: 1
       }
     }, null, (err) => {
-      expect(err.isJoi).toBe(true);
+      expect(isCelebrate(err)).toBe(true);
       expect(err.details[0].message).toBe('"end" is not allowed');
     });
   });
@@ -100,7 +101,7 @@ describe('Celebrate Middleware', () => {
       },
       method: 'POST'
     }, null, (err) => {
-      expect(err.isJoi).toBe(true);
+      expect(isCelebrate(err)).toBe(true);
       expect(err.details[0].message).toBe('"last" must be a string');
     });
   });
@@ -133,7 +134,7 @@ describe('Celebrate Middleware', () => {
         last: 123
       }
     }, null, (err) => {
-      expect(err.isJoi).toBe(true);
+      expect(isCelebrate(err)).toBe(true);
       expect(err.details[0].message).toBe('"end" is not allowed');
     });
   });
@@ -219,7 +220,7 @@ describe('Celebrate Middleware', () => {
       },
       method: 'POST'
     }, null, (err) => {
-      expect(err.isJoi).toBe(true);
+      expect(isCelebrate(err)).toBe(true);
       expect(err.details[0].message).toBe('"first" must equal "john"');
     });
   });
@@ -258,7 +259,7 @@ describe('Celebrate Middleware', () => {
         accept: 'application/json'
       }
     }, null, (err) => {
-      expect(err.isJoi).toBe(true);
+      expect(isCelebrate(err)).toBe(true);
       expect(err.details[0].message).toBe('"accept" with value "application/json" fails to match the required pattern: /xml/');
     });
   });
@@ -347,6 +348,43 @@ describe('Celebrate Middleware', () => {
           err.details = null;
           handler(err, undefined, res, next);
       });
+    });
+  });
+
+  describe('isCelebrate', () => {
+    it('returns false if the error object did not originate from celebrate', () => {
+      expect.assertions(1);
+      expect(isCelebrate(Error())).toBe(false);
+    });
+    
+    it('returns false if the error object is not an object', () => {
+      expect.assertions(3);
+      expect(isCelebrate('errr')).toBe(false);
+      expect(isCelebrate(0)).toBe(false);
+      expect(isCelebrate([1,2])).toBe(false);
+    });
+
+    it('returns false if the error object is fasly', () => {
+      expect.assertions(2);
+      expect(isCelebrate(null)).toBe(false);
+      expect(isCelebrate(undefined)).toBe(false);
+    });
+
+    it('returns true if the error object came from celebrate', () => {
+        expect.assertions(1);
+        const middleware = celebrate({
+          headers: {
+            accept: Joi.string().regex(/xml/)
+          }
+        });
+    
+        middleware({
+          headers: {
+            accept: 'application/json'
+          }
+        }, null, (err) => {
+          expect(isCelebrate(err)).toBe(true);
+        });
     });
   });
 });


### PR DESCRIPTION
Closes #51

Expose an "isCelebrate" method to allow custom error middleware handlers a reliable way to check
to see if in incomming error came from celebrate or not.