### PR TITLE
Strongly type Joi export

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,5 @@
 import { ErrorRequestHandler, RequestHandler } from 'express';
+import { Root as joi } from 'joi';
 
 declare namespace Celebrate {
     /**
@@ -22,7 +23,7 @@ declare namespace Celebrate {
     /**
      * The Joi version Celebrate uses internally.
      */
-    export const Joi: object;
+    export const Joi: joi
 
     /**
      * Examines an error object to determine if it originated from the celebrate middleware.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@types/express": "4.x.x",
+    "@types/joi": "13.0.0",
     "artificial": "0.1.x",
     "belly-button": "4.x.x",
     "body-parser": "1.18.2",


### PR DESCRIPTION
Closes #56

Type the exported Joi object to as a @types/joi object. Pin the version as it's
technically for version 13 of Joi, but at moment, 12 and 13 have the same
exported API. This will probably change in the future.