### PR TITLE
Perf updates

### DIFF
--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const Benchmark = require('benchmark');
+const { celebrate, Joi } = require('../lib');
+const middleware = celebrate({
+  body: {
+    name: Joi.string().allow('adam').required()
+  }
+});
+
+const suite = new Benchmark.Suite();
+const noop = () => {};
+
+suite.add('valid', () => {
+  middleware({
+    body: {
+      name: 'adam'
+    },
+    method: 'post'
+  }, {}, noop);
+}).add('invalid', () => {
+  middleware({
+    body: {},
+    method: 'post'
+  }, {}, noop);
+});
+
+suite.on('complete', function suiteComplete() {
+  for (let i = 0; i < this.length; i += 1) {
+    console.log(this[i].toString());
+  }
+});
+
+suite.run();

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,25 +21,27 @@ const validateSource = (source) => {
     if (!spec) {
       return next(null);
     }
-    Joi.validate(req[source], spec, options, (err, value) => {
-      if (value !== undefined) {
-        const descriptor = Object.getOwnPropertyDescriptor(req, source);
-        /* istanbul ignore next */
-        if (descriptor && descriptor.writable) {
-          req[source] = value;
-        } else {
-          Object.defineProperty(req, source, {
-            get () { return value; }
-          });
-        }
+    const result = Joi.validate(req[source], spec, options);
+    const value = result.value;
+    const err = result.error;
+
+    if (value !== undefined) {
+      const descriptor = Object.getOwnPropertyDescriptor(req, source);
+      /* istanbul ignore next */
+      if (descriptor && descriptor.writable) {
+        req[source] = value;
+      } else {
+        Object.defineProperty(req, source, {
+          get () { return value; }
+        });
       }
-      if (err) {
-        err[CELEBRATED] = true;
-        err._meta = { source };
-        return next(err);
-      }
-      return next(null);
-    });
+    }
+    if (err) {
+      err[CELEBRATED] = true;
+      err._meta = { source };
+      return next(err);
+    }
+    return next(null);
   };
 };
 
@@ -47,6 +49,22 @@ const validateHeaders = validateSource('headers');
 const validateParams = validateSource('params');
 const validateQuery = validateSource('query');
 const validateBody = validateSource('body');
+const maybeValidateBody = (config, callback) => {
+  const method = config.req.method.toLowerCase();
+
+  if (method === 'get' || method === 'head') {
+    return callback(null);
+  }
+
+  validateBody(config, callback);
+};
+
+const REQ_VALIDATIONS = [
+  validateHeaders,
+  validateParams,
+  validateQuery,
+  maybeValidateBody
+];
 
 const isCelebrate = (err) => {
   if (err != null && typeof err === 'object') { // eslint-disable-line eqeqeq
@@ -67,18 +85,7 @@ const celebrate = (schema, options) => {
     rules.set(key, Joi.compile(schema[key]));
   }
   const middleware = (req, res, next) => {
-    Series(null, [
-      validateHeaders,
-      validateParams,
-      validateQuery,
-      (config, callback) => {
-        const method = config.req.method.toLowerCase();
-        if (method === 'get' || method === 'head') {
-          return callback(null);
-        }
-        validateBody(config, callback);
-      }
-    ], {
+    Series(null, REQ_VALIDATIONS, {
       req,
       options: joiOpts,
       rules

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "lint": "belly-button -i 'lib/*.js' -f",
-    "test": "npm run lint && jest --ci"
+    "test": "npm run lint && jest --ci",
+    "benchmark": "node benchmarks/index"
   },
   "repository": {
     "type": "git",
@@ -34,6 +35,7 @@
     "@types/joi": "13.0.0",
     "artificial": "0.1.x",
     "belly-button": "4.x.x",
+    "benchmark": "2.1.4",
     "body-parser": "1.18.2",
     "expect": "21.2.x",
     "express": "5.0.0-alpha.6",


### PR DESCRIPTION
Added some benchmarking tooling to have an idea of how changes affect
performance 
Moved code around to allow for more constant values and fewer memory
allocations 
Switch to non-callback validation function to remove extra closure

We may want to log the benchmarks to see how that look over time or across different node versions...

```
valid x 28,130 ops/sec ±1.68% (85 runs sampled)
invalid x 16,185 ops/sec ±1.85% (85 runs sampled)
```
This run was with these changes on node 6

Previous run before changes

```
valid x 27,035 ops/sec ±1.02% (82 runs sampled)
invalid x 15,341 ops/sec ±1.72% (80 runs sampled)
```